### PR TITLE
Expose a simplistic {sendfile} reply

### DIFF
--- a/src/Erl/Cowboy/Req.erl
+++ b/src/Erl/Cowboy/Req.erl
@@ -1,7 +1,13 @@
 -module(erl_cowboy_req@foreign).
--export([reply/4,replyWithoutBody/3,replyStatus/2,method/1,versionImpl/4,scheme/1,bindingWithDefault/3,bindingImpl/4,pathInfo/1,host/1,port/1,path/1,qs/1,headerImpl/4,headers/1,setHeader/3,setBody/2, setCookie/3, peer/1, readBodyImpl/3, streamReply/3, streamBody/2, streamBodyFinal/2]).
+-include_lib("kernel/include/file.hrl").
+-export([reply/4,replyWithoutBody/3,replyWithFile/4,replyStatus/2,method/1,versionImpl/4,scheme/1,bindingWithDefault/3,bindingImpl/4,pathInfo/1,host/1,port/1,path/1,qs/1,headerImpl/4,headers/1,setHeader/3,setBody/2, setCookie/3, peer/1, readBodyImpl/3, streamReply/3, streamBody/2, streamBodyFinal/2]).
 
 reply(Status, Headers, Body, Req) -> fun () -> cowboy_req:reply(Status, Headers, Body, Req) end.
+
+replyWithFile(Status, Headers, Filename, Req) -> fun () ->
+  {ok, #file_info{size = Size}} = file:read_file_info(Filename),
+  cowboy_req:reply(Status, Headers, {sendfile, 0, Size, Filename}, Req)
+  end.
 
 replyWithoutBody(Status, Headers, Req) -> fun () -> cowboy_req:reply(Status, Headers, Req) end.
 

--- a/src/Erl/Cowboy/Req.erl
+++ b/src/Erl/Cowboy/Req.erl
@@ -1,5 +1,5 @@
 -module(erl_cowboy_req@foreign).
--export([reply/4,replyWithoutBody/3,replyStatus/2,method/1,versionImpl/4,scheme/1,bindingWithDefault/3,bindingImpl/4,pathInfo/1,host/1,port/1,path/1,qs/1,headerImpl/4,headers/1,setHeader/3,setBody/2, setCookie/3, peer/1, readBodyImpl/3, streamReply/3, streamBody/2, streamBodyFinal/2]).
+-export([reply/4,replyWithoutBody/3,replyStatus/2,method/1,versionImpl/4,scheme/1,bindingWithDefault/3,bindingImpl/4,pathInfo/1,host/1,port/1,path/1,qs/1,headerImpl/4,headers/1,setHeader/3,setBody/2, setCookie/3, peer/1, readBodyImpl/3, readUrlEncodedBodyImpl/2, streamReply/3, streamBody/2, streamBodyFinal/2]).
 
 reply(Status, Headers, Body, Req) -> fun () -> cowboy_req:reply(Status, Headers, Body, Req) end.
 
@@ -56,6 +56,12 @@ readBodyImpl(FullData, PartialData, Req) ->
       {ok, D, Req2} -> (FullData(D))(Req2);
       {more, D, Req2} -> (PartialData(D))(Req2)
     end
+  end.
+
+readUrlEncodedBodyImpl(Result, Req) ->
+  fun() ->
+      {ok, Items, Req2 } = cowboy_req:read_urlencoded_body(Req),
+      (Result(Items))(Req2)
   end.
 
 streamReply(Status, Headers, Req) -> fun () ->

--- a/src/Erl/Cowboy/Req.erl
+++ b/src/Erl/Cowboy/Req.erl
@@ -1,6 +1,6 @@
 -module(erl_cowboy_req@foreign).
--include_lib("kernel/include/file.hrl").
 -export([reply/4,replyWithoutBody/3,replyWithFile/4,replyStatus/2,method/1,versionImpl/4,scheme/1,bindingWithDefault/3,bindingImpl/4,pathInfo/1,host/1,port/1,path/1,qs/1,headerImpl/4,headers/1,setHeader/3,setBody/2, setCookie/3, peer/1, readBodyImpl/3, readUrlEncodedBodyImpl/2, streamReply/3, streamBody/2, streamBodyFinal/2, parseCookies/1]).
+-include_lib("kernel/include/file.hrl").
 
 reply(Status, Headers, Body, Req) -> fun () -> cowboy_req:reply(Status, Headers, Body, Req) end.
 

--- a/src/Erl/Cowboy/Req.erl
+++ b/src/Erl/Cowboy/Req.erl
@@ -1,6 +1,6 @@
 -module(erl_cowboy_req@foreign).
 -include_lib("kernel/include/file.hrl").
--export([reply/4,replyWithoutBody/3,replyWithFile/4,replyStatus/2,method/1,versionImpl/4,scheme/1,bindingWithDefault/3,bindingImpl/4,pathInfo/1,host/1,port/1,path/1,qs/1,headerImpl/4,headers/1,setHeader/3,setBody/2, setCookie/3, peer/1, readBodyImpl/3, streamReply/3, streamBody/2, streamBodyFinal/2]).
+-export([reply/4,replyWithoutBody/3,replyWithFile/4,replyStatus/2,method/1,versionImpl/4,scheme/1,bindingWithDefault/3,bindingImpl/4,pathInfo/1,host/1,port/1,path/1,qs/1,headerImpl/4,headers/1,setHeader/3,setBody/2, setCookie/3, peer/1, readBodyImpl/3, readUrlEncodedBodyImpl/2, streamReply/3, streamBody/2, streamBodyFinal/2, parseCookies/1]).
 
 reply(Status, Headers, Body, Req) -> fun () -> cowboy_req:reply(Status, Headers, Body, Req) end.
 

--- a/src/Erl/Cowboy/Req.erl
+++ b/src/Erl/Cowboy/Req.erl
@@ -1,5 +1,5 @@
 -module(erl_cowboy_req@foreign).
--export([reply/4,replyWithoutBody/3,replyStatus/2,method/1,versionImpl/4,scheme/1,bindingWithDefault/3,bindingImpl/4,pathInfo/1,host/1,port/1,path/1,qs/1,headerImpl/4,headers/1,setHeader/3,setBody/2, setCookie/3, peer/1, readBodyImpl/3, readUrlEncodedBodyImpl/2, streamReply/3, streamBody/2, streamBodyFinal/2]).
+-export([reply/4,replyWithoutBody/3,replyStatus/2,method/1,versionImpl/4,scheme/1,bindingWithDefault/3,bindingImpl/4,pathInfo/1,host/1,port/1,path/1,qs/1,headerImpl/4,headers/1,setHeader/3,setBody/2, setCookie/3, peer/1, readBodyImpl/3, readUrlEncodedBodyImpl/2, streamReply/3, streamBody/2, streamBodyFinal/2, parseCookies/1]).
 
 reply(Status, Headers, Body, Req) -> fun () -> cowboy_req:reply(Status, Headers, Body, Req) end.
 
@@ -50,6 +50,9 @@ setCookie(Name, Value, Req) -> cowboy_req:set_resp_cookie(Name, Value, Req).
 setBody(Body, Req) -> cowboy_req:set_resp_body(Body, Req).
 
 peer(Req) -> cowboy_req:peer(Req).
+
+parseCookies(Req) ->
+  cowboy_req:parse_cookies(Req).
 
 readBodyImpl(FullData, PartialData, Req) ->
   fun() -> case cowboy_req:read_body(Req) of

--- a/src/Erl/Cowboy/Req.purs
+++ b/src/Erl/Cowboy/Req.purs
@@ -10,6 +10,7 @@ module Erl.Cowboy.Req
   , Req
   , reply
   , replyWithoutBody
+  , replyWithFile
   , replyStatus
   , method
   , Version(..)
@@ -57,6 +58,9 @@ foreign import reply :: StatusCode -> Headers -> String -> Req -> Effect Req
 
 -- | Send the reply without setting the body (cowboy_req:reply/3)
 foreign import replyWithoutBody :: StatusCode -> Headers -> Req -> Effect Req
+
+-- | Send the reply including a file as the body
+foreign import replyWithFile :: StatusCode -> Headers -> String -> Req -> Effect Req
 
 -- | Send the reply with already set headers and body (cowboy_req:reply/2)
 foreign import replyStatus :: StatusCode -> Req -> Effect Req

--- a/src/Erl/Cowboy/Req.purs
+++ b/src/Erl/Cowboy/Req.purs
@@ -33,6 +33,7 @@ module Erl.Cowboy.Req
   , setBody
   , IpAddress
   , peer
+  , parseCookies
   , streamReply
   , streamBody
   , streamBodyFinal
@@ -135,6 +136,8 @@ foreign import setBody :: String -> Req -> Req
 type IpAddress = Tuple4 Int Int Int Int
 
 foreign import peer :: Req -> Tuple2 IpAddress Int
+
+foreign import parseCookies :: Req -> List (Tuple2 String String)
 
 -- Streaming responses
 

--- a/src/Erl/Cowboy/Req.purs
+++ b/src/Erl/Cowboy/Req.purs
@@ -28,6 +28,7 @@ module Erl.Cowboy.Req
   , ReadUrlEncodedBodyResult(..)
   , readBody
   , readUrlEncodedBody
+  , setCookie
   , setHeader
   , setBody
   , IpAddress

--- a/src/Erl/Cowboy/Req.purs
+++ b/src/Erl/Cowboy/Req.purs
@@ -25,7 +25,9 @@ module Erl.Cowboy.Req
   , header
   , headers
   , ReadBodyResult(..)
+  , ReadUrlEncodedBodyResult(..)
   , readBody
+  , readUrlEncodedBody
   , setHeader
   , setBody
   , IpAddress
@@ -108,6 +110,16 @@ foreign import readBodyImpl :: (Binary -> Req -> ReadBodyResult) -> (Binary -> R
 
 readBody :: Req -> Effect ReadBodyResult
 readBody = readBodyImpl FullData PartialData
+
+
+-- and the helper for url encoded  body
+
+data ReadUrlEncodedBodyResult = UrlEncodedBody (List (Tuple2 String String)) Req
+
+foreign import readUrlEncodedBodyImpl :: ((List (Tuple2 String String)) -> Req -> ReadUrlEncodedBodyResult) ->  Req -> Effect ReadUrlEncodedBodyResult
+
+readUrlEncodedBody :: Req -> Effect ReadUrlEncodedBodyResult
+readUrlEncodedBody = readUrlEncodedBodyImpl UrlEncodedBody
 
 -- Writing a response
 

--- a/src/Erl/Cowboy/Req/Monad.purs
+++ b/src/Erl/Cowboy/Req/Monad.purs
@@ -1,6 +1,7 @@
 module Erl.Cowboy.Req.Monad
 ( reply
 , replyWithoutBody
+, replyWithFile
 , replyStatus
 , streamReply
 , streamBody
@@ -27,6 +28,9 @@ reply s h b = modifyEffect_ (Req.reply s h b)
 
 replyWithoutBody :: forall m. MonadState Req.Req m => MonadEffect m => Req.StatusCode -> Req.Headers -> m Unit
 replyWithoutBody s h = modifyEffect_ (Req.replyWithoutBody s h)
+
+replyWithFile :: forall m. MonadState Req.Req m => MonadEffect m => Req.StatusCode -> Req.Headers -> String -> m Unit
+replyWithFile s h f = modifyEffect_ (Req.replyWithFile s h f)
 
 replyStatus :: forall m. MonadState Req.Req m => MonadEffect m => Req.StatusCode -> m Unit
 replyStatus s = modifyEffect_ (Req.replyStatus s)


### PR DESCRIPTION
Expose a way to use cowboy's {sendfile,...} body to return an existing file to the client.
Cowboy requires an offset and length of data to return but 100% of my use cases are "send the whole file" so these options aren't exposed.
I considered returning Either Reason Effect Req for a non-existent file but preferred the consistent signature with the other replyX